### PR TITLE
Add script for automatic update of commons page

### DIFF
--- a/utils/get_commons_readme.rb
+++ b/utils/get_commons_readme.rb
@@ -1,0 +1,13 @@
+require 'open-uri'
+
+full_readme = open('https://raw.githubusercontent.com/AbsaOSS/commons/master/README.md').read
+readme_without_header = full_readme.split("\n")[2..-1].join("\n")
+
+gh_pages_header = "---\n" +
+                  "layout: default\n" +
+                  "title: ABSA Commons\n" +
+                  "---\n\n"
+
+new_readme = gh_pages_header + readme_without_header
+
+File.write "#{__dir__}/../commons.md", new_readme


### PR DESCRIPTION
Because commons is supposed to be updated each time it is updated, a small script that will get the newest readme, rewrite the old, append liquid and you then just commit.