### PR TITLE
Fix about ABRiS typo

### DIFF
--- a/info-abris.md
+++ b/info-abris.md
@@ -3,4 +3,4 @@ layout: default
 title: ABRiS
 ---
 
-For now, please refer to the GitHub repository of [Atum](https://github.com/AbsaOSS/ABRiS)
+For now, please refer to the GitHub repository of [ABRiS](https://github.com/AbsaOSS/ABRiS)


### PR DESCRIPTION
ABRiS isn't Atum. Correct link, incorrect name.